### PR TITLE
Fix/imf ids

### DIFF
--- a/R/data_functions.R
+++ b/R/data_functions.R
@@ -20,7 +20,9 @@ imf_ids <- function(return_raw = FALSE, times = 3) {
 
     if (!isTRUE(return_raw)) {
         data_id <- purrr::map_chr(raw_dl$Structure$Dataflows$Dataflow,
-                                  ~ .x %>% `[[`("@id") %>% stringr::str_sub(start = 4L))
+                                  ~ .x %>% `[[`("@id") %>%
+                                      stringr::str_sub(start = 4L) %>%
+                                      stringr::str_replace("\n$", ""))
 
         long_name <- purrr::map_chr(raw_dl$Structure$Dataflows$Dataflow,
                                     ~ .x %>% `[[`("Name") %>% `[[`("#text"))

--- a/R/data_functions.R
+++ b/R/data_functions.R
@@ -14,19 +14,14 @@
 #' @export
 
 imf_ids <- function(return_raw = FALSE, times = 3) {
-    URL <- "http://dataservices.imf.org/REST/SDMX_JSON.svc/Dataflow"
-    raw_dl <- RETRY('GET', URL, user_agent(''), progress(), times = times) %>%
-        content()
+    URL <- 'http://dataservices.imf.org/REST/SDMX_JSON.svc/Dataflow?format=sdmx-json'
+    raw_dl <- download_parse(URL)
 
     if (!isTRUE(return_raw)) {
-        data_id <- purrr::map_chr(raw_dl$Structure$Dataflows$Dataflow,
-                                  ~ .x %>% `[[`("@id") %>%
-                                      stringr::str_sub(start = 4L) %>%
-                                      stringr::str_replace("\n$", ""))
-
-        long_name <- purrr::map_chr(raw_dl$Structure$Dataflows$Dataflow,
-                                    ~ .x %>% `[[`("Name") %>% `[[`("#text"))
-
+        data_id <- raw_dl$Structure$Dataflows$Dataflow$`@id` %>%
+            sub("^DS-", "", .) %>%
+            sub("\n$", "", .)
+        long_name <- raw_dl$Structure$Dataflows$Dataflow$Name$`#text`
         id_name <- data.frame(database_id = data_id, description = long_name)
         return(id_name)
     }


### PR DESCRIPTION
After #11 was resolved, the output of the function imf_ids does not include even "IFS". I have checked http://datahelp.imf.org/knowledgebase/articles/667681-using-json-restful-web-service, and found http://dataservices.imf.org/REST/SDMX_JSON.svc/Dataflow (note: I have removed the last /) returns something. From that, I have managed to extract database_id and description.