### PR TITLE
Fix/imf_data_one better not to stop, but go next iteration

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -33,14 +33,18 @@ imf_data_one <- function(database_id, indicator, country, start,
         } else
             # Check if requested indicator and frequency is available
             overview <- raw_dl$CompactData$DataSet$Series
-            if (is.null(overview)) stop(sprintf(
-                '%s is not available for your query.', indicator),
-                call. = FALSE)
+            if (is.null(overview)) {
+                sprintf(
+                    '%s is not available for your query.', indicator)
+                next
+            }
 
             available_freq <- overview$`@FREQ`
-            if (!(freq %in% available_freq)) stop(sprintf(
-                    '%s is not available in the requested frequency', indicator),
-                                              call. = FALSE)
+            if (!(freq %in% available_freq)) {
+                sprintf(
+                    '%s is not available in the requested frequency', indicator)
+                next
+            }
 
         # Extract requested series
         observations <- raw_dl$CompactData$DataSet$Series$Obs


### PR DESCRIPTION
Thank you for merging my previous pull request.
This is another one. Download for all countries, like the example below, sometimes fails. As imf_data_one function does for loop to transact 60 countries by each, the last iteration may have small number of countries and those countries may not have requested indicator or frequency. I would like to propose imf_data_one function will not stop, but go next iteration, when it finds unavailable indicator or frequency.

[failed example]

```r
imf_data(database_id = "IFS",
               indicator = "GG_GALM_G01_XDC",
               country = "all",
               freq = "A",
               start = 1900, end = current_year()
)
```